### PR TITLE
feat: support skip-contribution-count

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ jobs:
 | skip-verify-authority | Skip verify by creator authority. Option: `read` `write` `admin` | string | ✖ |
 | skip-verify-users | Skip verify by creator userid. Support multiple | string | ✖ |
 | skip-label | Skip label | string | ✖ |
+| skip-count | Skip verify by commit count | number | ✖ |
 | comment | Comment when verification success | string | ✖ |
 | comment-mark | Comment mark to find. | string | ✖ |
 | assignees | Assignees when verification success | string | ✖ |

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ jobs:
 | skip-verify-authority | Skip verify by creator authority. Option: `read` `write` `admin` | string | ✖ |
 | skip-verify-users | Skip verify by creator userid. Support multiple | string | ✖ |
 | skip-label | Skip label | string | ✖ |
-| skip-count | Skip verify by commit count | number | ✖ |
+| skip-contribution-count | Skip verify by commit count | number | ✖ |
 | comment | Comment when verification success | string | ✖ |
 | comment-mark | Comment mark to find. | string | ✖ |
 | assignees | Assignees when verification success | string | ✖ |

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     description: Skip verify by github userid.
   skip-label:
     description: Skip verify by pr label.
-  skip-count:
+  skip-contribution-count:
     description: Skip verify by commits count.
   forbid-files:
     description: Forbid files. Higher than allowed.

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,8 @@ inputs:
     description: Skip verify by github userid.
   skip-label:
     description: Skip verify by pr label.
+  skip-count:
+    description: Skip verify by commits count.
   forbid-files:
     description: Forbid files. Higher than allowed.
   forbid-paths:
@@ -38,5 +40,5 @@ inputs:
     description: When hit, whether set failed.
 
 runs:
-  using: 'node12'
+  using: 'node20'
   main: 'dist/index.js'

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@umijs/fabric": "^2.5.6",
-    "@vercel/ncc": "^0.34.0",
+    "@vercel/ncc": "0.34.0",
     "prettier": "^2.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
   "dependencies": {
     "@actions/core": "^1.2.6",
     "@actions/github": "^4.0.0",
-    "@octokit/rest": "^18.0.14",
+    "@octokit/rest": "^22.0.0",
     "actions-util": "^1.0.0"
   },
   "devDependencies": {
     "@umijs/fabric": "^2.5.6",
-    "@vercel/ncc": "^0.27.0",
+    "@vercel/ncc": "^0.34.0",
     "prettier": "^2.2.1"
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -27,7 +27,7 @@ async function run() {
       const skipVerifyUsers = core.getInput('skip-verify-users');
       const skipLabel = core.getInput('skip-label');
       const setFailedInput = core.getInput('set-failed');
-      const skipCount = core.getInput('skip-count');
+      const skipContributionCount = core.getInput('skip-contribution-count');
 
       if (skipLabel && labels && labels.length) {
         const labelsName = labels.map(({ name }) => name);
@@ -84,9 +84,9 @@ async function run() {
           owner,
           repo,
           author: creator,
-          per_page: skipCount,
-        })
-        const out = res.data.length >= skipCount;
+          per_page: skipContributionCount,
+        });
+        const out = res.data.length >= skipContributionCount;
         core.info(`The user ${creator} check commits count ${out}!`);
         return out;
       }
@@ -97,7 +97,7 @@ async function run() {
         result = await checkAuthority();
       }
 
-      if (!result && skipCount) {
+      if (!result && skipContributionCount) {
         result = await checkCommitsCount();
       }
 


### PR DESCRIPTION
希望能增加一个类似 skip-count 的参数来跳过对长期贡献者的文件检查。

antd 侧，这个 ci 主要用于一些拿来拦截一些恶意或无效 PR的，但是也有许多长期贡献者但还不是正式成员也会被拦截，所以希望用一个count的设置来避免 close。
1. close 还得需要member 人工reopen，并且close之后会阻挡贡献者继续commit，还是有点麻烦。
2. skip-verify-users 需要一个个加名字也不方便。

![image](https://github.com/user-attachments/assets/62cb229c-e978-4c62-a1ee-b6c46366f321)
